### PR TITLE
トップページにヘッダーを追加・クイズページのリファクタ

### DIFF
--- a/frontend/src/app/(user)/(auth)/signin/page.tsx
+++ b/frontend/src/app/(user)/(auth)/signin/page.tsx
@@ -38,7 +38,7 @@ export default function SignIn() {
     <>
       <Container>
         <div className="px-6 flex justify-center">
-          <div className="flex flex-col items-center w-1/2 min-w-80 mt-16 ring-1 ring-gray-300 py-10 px-16 rounded-md shadow-lg">
+          <div className="flex flex-col items-center w-1/2 min-w-80 mt-16 ring-1 ring-gray-300 py-10 px-16 rounded-md shadow-lg bg-white">
             <h1 className="text-3xl font-bold leading-9 tracking-tight text-gray-900">
               ログイン
             </h1>

--- a/frontend/src/app/(user)/(auth)/signup/page.tsx
+++ b/frontend/src/app/(user)/(auth)/signup/page.tsx
@@ -45,7 +45,7 @@ export default function SignUp() {
     <>
       <Container>
         <div className="px-6 flex justify-center">
-          <div className="flex flex-col items-center w-1/2 min-w-80 mt-16 ring-1 ring-gray-300 py-10 px-16 rounded-md shadow-lg">
+          <div className="flex flex-col items-center w-1/2 min-w-80 mt-16 ring-1 ring-gray-300 py-10 px-16 rounded-md shadow-lg bg-white">
             <h1 className="text-3xl font-bold text-gray-900">新規登録</h1>
             <form
               action=""

--- a/frontend/src/app/(user)/(project)/work/[id]/page.tsx
+++ b/frontend/src/app/(user)/(project)/work/[id]/page.tsx
@@ -1,25 +1,65 @@
 "use client";
 
+import { RobotTalkIcon } from "@/components/Icons/RobotTalkIcon";
 import { ChatBot } from "@/components/chatbot/ChatBot";
 import { IDE } from "@/components/editor/CodeEditor";
 import { ReturnBox } from "@/components/editor/ReturnBox";
-import { Grid } from "@mui/material";
+import { useTheme } from "@emotion/react";
+import ChevronLeftIcon from "@mui/icons-material/ChevronLeft";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import { Drawer, IconButton, Tooltip } from "@mui/material";
+import { styled } from "@mui/material/styles";
 import { useSearchParams } from "next/navigation";
+import React, { useState } from "react";
 
 export default function QuizPage() {
   const searchParams = useSearchParams();
   const title = searchParams.get("title");
   const content = searchParams.get("content");
+  const theme = useTheme();
+  const [open, setOpen] = useState<boolean>(true);
+
+  const handleDrawerClose = () => {
+    setOpen(false);
+  };
+
+  const handleDrawerOpen = () => {
+    setOpen(true);
+  };
 
   console.log(content);
 
+  const DrawerHeader = styled("div")(({ theme }) => ({
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    padding: theme.spacing(0, 1),
+    // necessary for content to be below app bar
+    ...theme.mixins.toolbar,
+  }));
+
   return (
-    <div className="h-50 m-10">
-      <Grid container spacing={4}>
-        <Grid item xs={12} sm={12} md={7} lg={7} xl={7}>
+    <React.Fragment>
+      <div className="h-50 m-10">
+        <div
+          style={{ margin: "0px 100px", marginRight: open ? "400px" : "100px" }}
+        >
           <div className="mb-3">
-            <h1 className="text-2xl font-bold">{title}</h1>
-            <div className="whitespace-pre-wrap mt-2">{content}</div>
+            <div className="flex justify-between">
+              <div>
+                <h1 className="text-2xl font-bold">{title}</h1>
+                <div className="whitespace-pre-wrap mt-2">{content}</div>
+              </div>
+              {open ? (
+                <></>
+              ) : (
+                <Tooltip title="Chat for Hint">
+                  <IconButton onClick={handleDrawerOpen}>
+                    <RobotTalkIcon />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </div>
           </div>
           <div>
             <IDE />
@@ -27,11 +67,32 @@ export default function QuizPage() {
           <div className="mt-5">
             <ReturnBox />
           </div>
-        </Grid>
-        <Grid item xs={12} sm={12} md={5} lg={5} xl={5}>
-          <ChatBot />
-        </Grid>
-      </Grid>
-    </div>
+        </div>
+
+        <Drawer
+          sx={{
+            width: "400px",
+            flexShrink: 0,
+            "& .MuiDrawer-paper": {
+              width: "400px",
+              boxSizing: "border-box",
+            },
+          }}
+          variant="persistent"
+          anchor="right"
+          open={open}
+        >
+          <div className="mt-12">
+            <DrawerHeader>
+              <IconButton onClick={handleDrawerClose}>
+                {open ? <ChevronRightIcon /> : <ChevronLeftIcon />}
+              </IconButton>
+              ヒントボット
+            </DrawerHeader>
+            <ChatBot />
+          </div>
+        </Drawer>
+      </div>
+    </React.Fragment>
   );
 }

--- a/frontend/src/app/(user)/(project)/work/[id]/page.tsx
+++ b/frontend/src/app/(user)/(project)/work/[id]/page.tsx
@@ -41,7 +41,6 @@ export default function QuizPage({ params }: { params: { id: string } }) {
   }, [id]);
 
   useEffect(() => {
-    console.log("タイムスタンプを時間に変換します");
     const currentTime = new Date(calcTime);
     const h = String(currentTime.getHours() - 9).padStart(2, "0");
     const m = String(currentTime.getMinutes()).padStart(2, "0");
@@ -50,8 +49,7 @@ export default function QuizPage({ params }: { params: { id: string } }) {
     //　ミリ秒表示
     // setDisplayTime(`${h}:${m}:${s}:${ms}`);
     setDisplayTime(`${h}:${m}:${s}`);
-    console.log(displayTime);
-  }, [calcTime]);
+  }, [calcTime, setDisplayTime]);
 
   const handleDrawerClose = () => {
     setOpen(false);
@@ -75,7 +73,11 @@ export default function QuizPage({ params }: { params: { id: string } }) {
       <div>{displayTime}</div>
       <div className="h-50 m-10">
         <div
-          style={{ margin: "0px 100px", marginRight: open ? "400px" : "100px" }}
+          style={{
+            margin: "0px 50px",
+            marginRight: open ? "400px" : "50px",
+            minWidth: "500px",
+          }}
         >
           <div className="mb-3">
             <div className="flex justify-between">

--- a/frontend/src/app/(user)/(project)/work/[id]/page.tsx
+++ b/frontend/src/app/(user)/(project)/work/[id]/page.tsx
@@ -10,14 +10,48 @@ import ChevronRightIcon from "@mui/icons-material/ChevronRight";
 import { Drawer, IconButton, Tooltip } from "@mui/material";
 import { styled } from "@mui/material/styles";
 import { useSearchParams } from "next/navigation";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 
-export default function QuizPage() {
+export default function QuizPage({ params }: { params: { id: string } }) {
   const searchParams = useSearchParams();
   const title = searchParams.get("title");
   const content = searchParams.get("content");
-  const theme = useTheme();
   const [open, setOpen] = useState<boolean>(true);
+  const [displayTime, setDisplayTime] = useState("00:00:00");
+  const [calcTime, setcalcTime] = useState(0);
+  const theme = useTheme();
+  const id = params.id;
+
+  useEffect(() => {
+    const localStrageID = localStorage.getItem("id");
+    if (localStrageID != id) {
+      localStorage.removeItem("messages");
+      localStorage.setItem("id", id);
+      localStorage.setItem("start_time", Date.now().toString());
+    }
+    if (localStorage.getItem("start_time") == null) {
+      localStorage.setItem("start_time", Date.now().toString());
+    }
+    const start = localStorage.getItem("start_time");
+    if (start) {
+      const timerInterval = window.setInterval(() => {
+        setcalcTime(Date.now() - Number(start));
+      }, 1000);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    console.log("タイムスタンプを時間に変換します");
+    const currentTime = new Date(calcTime);
+    const h = String(currentTime.getHours() - 9).padStart(2, "0");
+    const m = String(currentTime.getMinutes()).padStart(2, "0");
+    const s = String(currentTime.getSeconds()).padStart(2, "0");
+    const ms = String(currentTime.getMilliseconds()).padStart(3, "0");
+    //　ミリ秒表示
+    // setDisplayTime(`${h}:${m}:${s}:${ms}`);
+    setDisplayTime(`${h}:${m}:${s}`);
+    console.log(displayTime);
+  }, [calcTime]);
 
   const handleDrawerClose = () => {
     setOpen(false);
@@ -26,8 +60,6 @@ export default function QuizPage() {
   const handleDrawerOpen = () => {
     setOpen(true);
   };
-
-  console.log(content);
 
   const DrawerHeader = styled("div")(({ theme }) => ({
     display: "flex",
@@ -40,6 +72,7 @@ export default function QuizPage() {
 
   return (
     <React.Fragment>
+      <div>{displayTime}</div>
       <div className="h-50 m-10">
         <div
           style={{ margin: "0px 100px", marginRight: open ? "400px" : "100px" }}
@@ -55,7 +88,7 @@ export default function QuizPage() {
               ) : (
                 <Tooltip title="Chat for Hint">
                   <IconButton onClick={handleDrawerOpen}>
-                    <RobotTalkIcon />
+                    <RobotTalkIcon size={45} />
                   </IconButton>
                 </Tooltip>
               )}

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -14,19 +14,13 @@
     --background-start-rgb: 0, 0, 0;
     --background-end-rgb: 0, 0, 0;
   }
-}
+} */
 
 body {
-  color: rgb(var(--foreground-rgb));
-  background: linear-gradient(
-      to bottom,
-      transparent,
-      rgb(var(--background-end-rgb))
-    )
-    rgb(var(--background-start-rgb));
+  background-color: #f5f5f5;
 }
 
-@layer utilities {
+/* @layer utilities {
   .text-balance {
     text-wrap: balance;
   }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,8 +1,20 @@
+"use client";
+import { ProjectHeader } from "@/components/headers/ProjectHeader";
+import { PublicHeader } from "@/components/headers/PublicHeader";
+import { useAuthContext } from "@/context/AuthContext";
 import { Box, Container } from "@mui/material";
+import { useEffect } from "react";
 
 export default function Home() {
+  const { currentUser } = useAuthContext();
+
+  useEffect(() => {
+    console.log(currentUser);
+  }, [currentUser]);
+
   return (
     <Box>
+      {currentUser ? <ProjectHeader /> : <PublicHeader />}
       <Container
         sx={{
           mt: 4,

--- a/frontend/src/components/Icons/RobotTalkIcon.tsx
+++ b/frontend/src/components/Icons/RobotTalkIcon.tsx
@@ -1,0 +1,18 @@
+import ChatIcon from "@mui/icons-material/Chat";
+import SmartToyIcon from "@mui/icons-material/SmartToy";
+
+export const RobotTalkIcon = () => {
+  return (
+    <div style={{ position: "relative" }}>
+      <SmartToyIcon sx={{ fontSize: 45 }} />
+      <ChatIcon
+        sx={{
+          fontSize: 30,
+          position: "absolute",
+          bottom: "25px",
+          left: "40px",
+        }}
+      />
+    </div>
+  );
+};

--- a/frontend/src/components/Icons/RobotTalkIcon.tsx
+++ b/frontend/src/components/Icons/RobotTalkIcon.tsx
@@ -1,16 +1,20 @@
 import ChatIcon from "@mui/icons-material/Chat";
 import SmartToyIcon from "@mui/icons-material/SmartToy";
 
-export const RobotTalkIcon = () => {
+type Props = {
+  size?: number;
+};
+
+export const RobotTalkIcon = ({ size = 45 }: Props) => {
   return (
     <div style={{ position: "relative" }}>
-      <SmartToyIcon sx={{ fontSize: 45 }} />
+      <SmartToyIcon sx={{ fontSize: size }} />
       <ChatIcon
         sx={{
-          fontSize: 30,
+          fontSize: (size * 2) / 3,
           position: "absolute",
-          bottom: "25px",
-          left: "40px",
+          bottom: `calc(${size}px - 20px)`,
+          left: `calc(${size})px`,
         }}
       />
     </div>

--- a/frontend/src/components/cards/QuizCard.tsx
+++ b/frontend/src/components/cards/QuizCard.tsx
@@ -16,7 +16,7 @@ export const QuizCard = ({ width, quiz }: Props) => {
   const router = useRouter();
   return (
     <div className="w-full">
-      <Card variant="outlined" sx={{ width: `100%`, padding: "0px" }}>
+      <Card sx={{ width: `100%`, padding: "0px" }}>
         <CardHeader
           sx={{ paddingBottom: "0px" }}
           titleTypographyProps={{ fontSize: "16px" }}

--- a/frontend/src/components/chatbot/ChatBot.tsx
+++ b/frontend/src/components/chatbot/ChatBot.tsx
@@ -14,8 +14,8 @@ export const ChatBot = () => {
   }, [messages]);
 
   return (
-    <div className="w-full">
-      <div className="border rounded-md relative" style={{ height: "80vh" }}>
+    <div className="w-full h-full">
+      <div className="border rounded-md relative h-full">
         <div
           ref={scrollRef}
           className="body p-6 overflow-scroll"

--- a/frontend/src/components/chatbot/ChatBot.tsx
+++ b/frontend/src/components/chatbot/ChatBot.tsx
@@ -13,6 +13,16 @@ export const ChatBot = () => {
     }
   }, [messages]);
 
+  useEffect(() => {
+    const serializedMessage = localStorage.getItem("messages");
+    if (serializedMessage) {
+      const array = JSON.parse(serializedMessage);
+      setMessages(array);
+    } else {
+      setMessages([]);
+    }
+  }, []);
+
   return (
     <div className="w-full h-full">
       <div className="border rounded-md relative h-full">

--- a/frontend/src/components/chatbot/MessageBox.tsx
+++ b/frontend/src/components/chatbot/MessageBox.tsx
@@ -37,7 +37,7 @@ export const MessageBox = ({ messages, setMessages }: Props) => {
     setMessages((prevMessages) => [...prevMessages, newMessage]);
     setUserMessage("");
 
-    // 5秒待機
+    // 2秒待機
     await sleep(2000);
 
     // 新しいメッセージオブジェクトのコピーを作成してaiプロパティを更新
@@ -47,8 +47,12 @@ export const MessageBox = ({ messages, setMessages }: Props) => {
     setMessages((prevMessages) => {
       const updatedMessages = [...prevMessages];
       updatedMessages[updatedMessages.length - 1] = updatedMessage;
+      const serializedArray = JSON.stringify(updatedMessages);
+      localStorage.setItem("messages", serializedArray);
       return updatedMessages;
     });
+
+    console.log(localStorage.getItem("messages"));
     setWait((prevState) => !prevState);
   };
 

--- a/frontend/src/components/chatbot/MessageBubble.tsx
+++ b/frontend/src/components/chatbot/MessageBubble.tsx
@@ -21,10 +21,11 @@ export const MessageBubble = ({ message, position }: Props) => {
         <Chip
           sx={{
             padding: "5px 0",
-            maxWidth: "50%",
+            maxWidth: "70%",
             height: "auto",
             "& .MuiChip-label": {
               whiteSpace: "pre-wrap",
+              overflowWrap: "break-word",
             },
             textAlign: "left",
           }}

--- a/frontend/src/components/editor/CodeEditor.tsx
+++ b/frontend/src/components/editor/CodeEditor.tsx
@@ -17,7 +17,7 @@ export const IDE = () => {
   };
   return (
     <div className="flex items-start flex-col">
-      <div className="w-full p-2  border">
+      <div className="w-full p-2  border bg-white">
         <div className="">
           <label htmlFor="comment" className="sr-only">
             Add your code

--- a/frontend/src/components/header/GlobalHeader.tsx
+++ b/frontend/src/components/header/GlobalHeader.tsx
@@ -9,10 +9,11 @@ export default function GlobalHeader({
     <AppBar
       elevation={0}
       color="default"
-      position="static"
+      position="sticky"
       sx={{
+        zIndex: (theme) => theme.zIndex.drawer + 1,
         height: `50px`,
-        backgroundColor: "white",
+        backgroundColor: "#000033",
         borderBottom: "1px solid lightgrey",
         width: "100%",
       }}

--- a/frontend/src/components/headers/ProjectHeader.tsx
+++ b/frontend/src/components/headers/ProjectHeader.tsx
@@ -11,6 +11,9 @@ export const ProjectHeader = () => {
   const SignOut = () => {
     signout().then(() => {
       document.cookie = "token=; Max-Age=0; Secure;";
+      localStorage.removeItem("id");
+      localStorage.removeItem("messages");
+      localStorage.removeItem("start_time");
       setCurrentUser(undefined);
       router.push("/");
     });

--- a/frontend/src/components/headers/ProjectHeader.tsx
+++ b/frontend/src/components/headers/ProjectHeader.tsx
@@ -1,3 +1,4 @@
+import { useAuthContext } from "@/context/AuthContext";
 import { signout } from "@/firebase/auth";
 import { Button, List, ListItem, ListItemButton } from "@mui/material";
 import { useRouter } from "next/navigation";
@@ -5,10 +6,12 @@ import GlobalHeader from "../header/GlobalHeader";
 
 export const ProjectHeader = () => {
   const router = useRouter();
+  const { setCurrentUser } = useAuthContext();
 
   const SignOut = () => {
     signout().then(() => {
       document.cookie = "token=; Max-Age=0; Secure;";
+      setCurrentUser(undefined);
       router.push("/");
     });
   };
@@ -30,7 +33,7 @@ export const ProjectHeader = () => {
                 router.push("/");
               }}
             >
-              <span className="mx-auto text-sm">Top</span>
+              <span className="mx-auto text-sm text-white">Top</span>
             </ListItemButton>
           </ListItem>
           <ListItem sx={{ width: "100px", padding: "0px" }}>
@@ -40,7 +43,7 @@ export const ProjectHeader = () => {
                 router.push("/work");
               }}
             >
-              <span className="mx-auto text-sm">問題一覧</span>
+              <span className="mx-auto text-sm text-white">問題一覧</span>
             </ListItemButton>
           </ListItem>
         </List>
@@ -49,7 +52,7 @@ export const ProjectHeader = () => {
             onClick={() => {
               SignOut();
             }}
-            color="secondary"
+            sx={{ color: "white" }}
           >
             サインアウト
           </Button>

--- a/frontend/src/components/headers/PublicHeader.tsx
+++ b/frontend/src/components/headers/PublicHeader.tsx
@@ -19,10 +19,30 @@ export const PublicHeader = () => {
           <ListItemButton
             sx={{ height: "100%" }}
             onClick={() => {
-              router.push("/work");
+              router.push("/");
             }}
           >
-            <span className="mx-auto text-sm">Top</span>
+            <span className="mx-auto text-sm text-white">Top</span>
+          </ListItemButton>
+        </ListItem>
+        <ListItem sx={{ width: "100px", padding: "0px" }}>
+          <ListItemButton
+            sx={{ height: "100%" }}
+            onClick={() => {
+              router.push("/signin");
+            }}
+          >
+            <span className="mx-auto text-sm text-white">ログイン</span>
+          </ListItemButton>
+        </ListItem>
+        <ListItem sx={{ width: "100px", padding: "0px" }}>
+          <ListItemButton
+            sx={{ height: "100%" }}
+            onClick={() => {
+              router.push("/signup");
+            }}
+          >
+            <span className="mx-auto text-sm text-white">新規登録</span>
           </ListItemButton>
         </ListItem>
       </List>


### PR DESCRIPTION
- quizページのチャットをサイドバーのような形で実装
- チャット履歴とかかった時間をlocalStrageに保存して、リロードやタブを閉じても残り続けるようにしました。
   -   別の問題を選択すると他の問題のlocalStorageの内容を削除